### PR TITLE
Add missing tag to scaling ASG by ECS

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -42,6 +42,14 @@ resource "aws_autoscaling_group" "tmp-asg" {
 
   # If you enable managedTerminationProtection on capacity provider, you have to enable this.
   # protect_from_scale_in = true
+
+  # This tag is required to scale instances by capacity provider
+  # ref: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = ""
+    propagate_at_launch = true
+  }
 }
 
 resource "aws_launch_template" "tmp-template" {


### PR DESCRIPTION
Thank you for your example to build an ECS and an ASG with a CP.
I found an invalid configuration which make ASG be not scaled in.

## What
- Add a required tag to the ASG
- ref:
  - [AWS Document](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-auto-scaling.html)
  - terraform-providers/terraform-provider-aws#12582